### PR TITLE
Refactor Dockerfile structure and update project references

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.gitignore
+bin
+obj
+**/bin
+**/obj
+tests
+.idea
+.vscode
+.gitmodules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: containers/action/Dockerfile
+          file: Dockerfile
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           load: ${{ github.event_name != 'push' || github.ref != 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -42,7 +42,7 @@
 - **Agent orchestration**: `src/IssueAgent.Agent/` (or equivalent namespace)
 - **Configuration defaults**: `src/IssueAgent.Configuration/`
 - **Tests**: `tests/IssueAgent.UnitTests/`, `tests/IssueAgent.IntegrationTests/`, `tests/IssueAgent.PerformanceTests/`
-- **Containers**: `containers/action/`
+- **Containers**: `Dockerfile`
 - Adjust names to match the actual solution (.sln) structure recorded in plan.md
 
 ## Phase 3.1: Setup
@@ -67,7 +67,7 @@
 
 ## Phase 3.4: Integration
 - [ ] T014 Implement GitHub API client adapter with retry/performance policies in `src/IssueAgent/Infrastructure/GitHub/GitHubClientAdapter.cs`
-- [ ] T015 Update prebuilt container specification in `containers/action/Dockerfile` with caching layers and publish script
+- [ ] T015 Update prebuilt container specification in `Dockerfile` with caching layers and publish script
 - [ ] T016 Add configuration migration helpers for new inputs in `src/IssueAgent.Configuration/Migrations/*.cs`
 - [ ] T017 Capture telemetry for cold-start timing and marketplace metrics in `src/IssueAgent/Infrastructure/Telemetry/ColdStartMetrics.cs`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,8 @@ RUN apk add --no-cache clang lld build-base zlib-dev
 # Copy solution and restore
 COPY Directory.Build.props Directory.Packages.props IssueAgent.sln ./
 COPY src ./src
-COPY tests ./tests
 
-RUN dotnet restore IssueAgent.sln
+RUN dotnet restore src/IssueAgent.Action/IssueAgent.Action.csproj
 
 # Publish self-contained AOT binary for linux-musl-x64
 RUN dotnet publish src/IssueAgent.Action/IssueAgent.Action.csproj \
@@ -23,7 +22,8 @@ RUN dotnet publish src/IssueAgent.Action/IssueAgent.Action.csproj \
     -p:PublishTrimmed=true \
     -p:InvariantGlobalization=true \
     -p:StripSymbols=true \
-    -o /app/publish
+    -o /app/publish \
+    --no-restore
 
 ########## Runtime ##########
 FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine AS runtime

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ dotnet test
 To build the Docker image locally:
 
 ```bash
-docker build -f containers/action/Dockerfile -t issueagent:local .
+docker build -f Dockerfile -t issueagent:local .
 ```
 
 To run the published AOT binary manually (requires environment variables similar to GitHub Actions):
@@ -114,7 +114,7 @@ The action publishes as a .NET 8 AOT single-file binary running on Alpine. Typic
 
 - `src/IssueAgent.Agent` — Core agent logic and GraphQL client
 - `src/IssueAgent.Action` — Action host that wires the agent into the Docker entrypoint
-- `containers/action/Dockerfile` — Multi-stage build producing the runtime image
+- `Dockerfile` — Multi-stage build producing the runtime image
 - `tests/` — Unit, contract, and integration test suites
 - `docs/operations` — Operations runbook for on-call responders
 - `docs/releases` — Release checklist to publish new versions

--- a/action.yml
+++ b/action.yml
@@ -16,4 +16,4 @@ inputs:
     default: "5"
 runs:
   using: "docker"
-  image: "containers/action/Dockerfile"
+  image: "Dockerfile"

--- a/containers/action/Dockerfile
+++ b/containers/action/Dockerfile
@@ -1,0 +1,8 @@
+# This stub exists only to guide developers to the new Dockerfile location.
+# The production Dockerfile now lives at the repository root.
+#
+# Update any local scripts to point to ./Dockerfile instead of this path.
+
+FROM alpine AS notice
+RUN echo "Dockerfile moved to repository root. Use 'docker build -f Dockerfile .'" \
+ && exit 1

--- a/docs/operations/issue-context-runbook.md
+++ b/docs/operations/issue-context-runbook.md
@@ -57,6 +57,6 @@ This runbook describes how to triage and remediate incidents involving the Issue
 ## Useful References
 
 - [GitHub Action metadata](../../action.yml)
-- [Dockerfile](../../containers/action/Dockerfile)
+- [Dockerfile](../../Dockerfile)
 - [GraphQL executor implementation](../../src/IssueAgent.Agent/GraphQL/IssueContextQueryExecutor.cs)
 - [README](../../README.md) for inputs and usage

--- a/specs/001-the-core-action/tasks.md
+++ b/specs/001-the-core-action/tasks.md
@@ -56,7 +56,7 @@
 - [X] T019 Implement Microsoft Agent Framework bootstrap wiring services in `src/IssueAgent.Agent/Runtime/AgentBootstrap.cs`.
 - [X] T020 Implement Docker entrypoint host that loads event payload and invokes the agent in `src/IssueAgent.Action/Program.cs` (with supporting `Scripts/entrypoint.sh`).
 - [X] T021 Define GitHub Action metadata with inputs/permissions in `action.yml`.
-- [X] T022 Author multi-stage publish recipe meeting <150 MB target in `containers/action/Dockerfile`.
+- [X] T022 Author multi-stage publish recipe meeting <150 MB target in `Dockerfile`.
 - [X] T023 Create publish automation script for container/image versioning in `src/IssueAgent.Action/Scripts/publish.sh`.
 
 ## Phase 3.4: Integration & Tooling

--- a/src/IssueAgent.Action/Scripts/publish.sh
+++ b/src/IssueAgent.Action/Scripts/publish.sh
@@ -28,7 +28,7 @@ IMAGE_REF_DEFAULT="ghcr.io/mattdot/issueagent"
 IMAGE_REF="${2:-$IMAGE_REF_DEFAULT}"
 PUSH=${PUSH:-true}
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-DOCKERFILE_PATH="${ROOT_DIR}/containers/action/Dockerfile"
+DOCKERFILE_PATH="${ROOT_DIR}/Dockerfile"
 
 IMAGE_TAG="${IMAGE_REF}:${VERSION}"
 


### PR DESCRIPTION
Restructure the Dockerfile location to the project root and update all references accordingly. Add a stub Dockerfile to guide developers to the new location.